### PR TITLE
Resolve #17

### DIFF
--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -184,7 +184,7 @@ let check_func_type (c : context) (ft : func_type) at =
 let check_cont_type (c : context) (ct : cont_type) at =
   match ct with
   | ContT (VarHT (StatX x)) ->
-     let _dt = func_type c (x @@ at) in ()
+    let _dt = func_type c (x @@ at) in ()
   | _ -> assert false
 
 let check_table_type (c : context) (tt : table_type) at =

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -185,7 +185,7 @@ let check_cont_type (c : context) (ct : cont_type) at =
   match ct with
   | ContT (VarHT (StatX x)) ->
      let _dt = func_type c (x @@ at) in ()
-  | _ -> error at "ill-formed continuation type"
+  | _ -> assert false
 
 let check_table_type (c : context) (tt : table_type) at =
   let TableT (lim, t) = tt in

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -183,7 +183,9 @@ let check_func_type (c : context) (ft : func_type) at =
 
 let check_cont_type (c : context) (ct : cont_type) at =
   match ct with
-  | ContT ft -> check_heap_type c ft at
+  | ContT (VarHT (StatX x)) ->
+     let _dt = func_type c (x @@ at) in ()
+  | _ -> error at "ill-formed continuation type"
 
 let check_table_type (c : context) (tt : table_type) at =
   let TableT (lim, t) = tt in

--- a/test/core/cont.wast
+++ b/test/core/cont.wast
@@ -205,6 +205,29 @@
       (drop)))
   "non-continuation type 0")
 
+(assert_invalid
+  (module
+    (type $ct (cont $ct)))
+  "non-function type 0")
+
+(assert_invalid
+  (module
+    (rec
+      (type $s0 (struct (field (ref 0) (ref 1) (ref $s0) (ref $s1))))
+      (type $s1 (struct (field (ref 0) (ref 1) (ref $s0) (ref $s1))))
+    )
+    (type $ct (cont $s0)))
+  "non-function type 0")
+
+(module
+  (rec
+    (type $f1 (func (param (ref $f2))))
+    (type $f2 (func (param (ref $f1))))
+  )
+  (type $c1 (cont $f1))
+  (type $c2 (cont $f2))
+)
+
 ;; Simple state example
 
 (module $state


### PR DESCRIPTION
This patch (re)installs the check for continuation type well-formedness.

Currently, it allows only continuation types to be indexed by plain function types.