### PR TITLE
Fix `table.set` for continuation tables

### DIFF
--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -83,7 +83,7 @@ type ref_ += ContRef of cont option ref
 let () =
   let type_of_ref' = !Value.type_of_ref' in
   Value.type_of_ref' := function
-    | ContRef _ -> BotHT  (* TODO *)
+    | ContRef _ -> ContHT
     | r -> type_of_ref' r
 
 let () =

--- a/interpreter/runtime/global.ml
+++ b/interpreter/runtime/global.ml
@@ -21,5 +21,4 @@ let load glob =
 let store glob v =
   let GlobalT (mut, t) = glob.ty in
   if mut <> Var then raise NotMutable;
-  if not (Match.match_val_type [] (type_of_value v) t) then raise Type;
   glob.content <- v

--- a/interpreter/runtime/table.ml
+++ b/interpreter/runtime/table.ml
@@ -53,7 +53,6 @@ let load tab i =
 
 let store tab i r =
   let TableT (lim, t) = tab.ty in
-  if not (Match.match_ref_type [] (type_of_ref r) t) then raise Type;
   if i < 0l || i >= Lib.Array32.length tab.content then raise Bounds;
   Lib.Array32.set tab.content i r
 

--- a/test/core/cont.wast
+++ b/test/core/cont.wast
@@ -654,3 +654,15 @@
     (drop)
   )
 )
+
+;; Globals
+(module
+  (type $ft (func))
+  (type $ct (cont $ft))
+
+  (global $k (mut (ref null $ct)) (ref.null $ct))
+  (global $g (ref null $ct) (ref.null $ct))
+
+  (func (param $c (ref $ct))
+    (global.set $k (local.get $c)))
+)

--- a/test/core/cont.wast
+++ b/test/core/cont.wast
@@ -663,6 +663,10 @@
   (global $k (mut (ref null $ct)) (ref.null $ct))
   (global $g (ref null $ct) (ref.null $ct))
 
-  (func (param $c (ref $ct))
-    (global.set $k (local.get $c)))
+  (func $f)
+  (elem declare func $f)
+
+  (func (export "set-global")
+    (global.set $k (cont.new $ct (ref.func $f))))
 )
+(assert_return (invoke "set-global"))


### PR DESCRIPTION
This patch fixes the failing type check that would sometimes occur when storing a continuation reference in a table. The solution: remove the type check. We cannot recover the type of a continuation reference without tracing block types in the interpreter.

Resolves #40. 