### PR TITLE
Tidy up w3c-publish workflow

### DIFF
--- a/.github/workflows/w3c-publish.yml
+++ b/.github/workflows/w3c-publish.yml
@@ -12,9 +12,6 @@ jobs:
   publish-to-w3c-TR:
     if: github.repository == 'WebAssembly/spec'
     runs-on: ubuntu-latest
-    # TODO(dhil): The following effectively disables this workflow. It
-    # should be removed before merging with upstream.
-    if: false
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
This patch removes a redundant hack, which was used to disable the w3c-publish workflow in downstream repositories.